### PR TITLE
Bug Fix

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: wildatlanticstudios

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.crx
 *.pem
 .idea
+.DS_Store

--- a/firefox/manifest.json
+++ b/firefox/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "BetterStreamChat",
-	"version": "1.3.4",
+	"version": "1.3.5",
 	"description": "Some settings for YouTube or Trovo chat.",
 	"manifest_version": 2,
 	"content_scripts": [

--- a/src/init.js
+++ b/src/init.js
@@ -662,24 +662,35 @@ const YouTube = {
                 const config = {attributes: true, childList: true, characterData: true};
                 observer.observe(target, config);
 
+                let isSetupSettingOptionDone = false;
+                const setupSettingOption = () => {
+                    if (isSetupSettingOptionDone) return;
+                    const node = this.document.querySelector('yt-live-chat-app iron-dropdown.yt-live-chat-app, yt-live-chat-app tp-yt-iron-dropdown.yt-live-chat-app');
+                    if (!node) return;
+                    isSetupSettingOptionDone = true;
+                    const paperItemTag = node.nodeName.toLowerCase() === 'iron-dropdown' ? 'paper-item' : 'tp-yt-paper-item';
+                    const settingOption = this.document.createElement('div');
+                    settingOption.style.cursor = 'pointer';
+                    settingOption.innerHTML = `<${paperItemTag} class="style-scope" role="option" tabindex="0" aria-disabled="false">BetterStreamChat</${paperItemTag}>`;
+                    node.querySelector('#items').appendChild(settingOption);
+                    settingOption.addEventListener('click', () => {
+                        BetterStreamChat.settingsDiv.style.display = 'block';
+                        this.document.body.click(); // click on body to close the settings container lol
+                    });
+                    const popupRenderer = node.querySelector('ytd-menu-popup-renderer');
+                    popupRenderer.style.removeProperty('max-height');
+                }
+                if (this.style && this.style.isConnected === false) this.style = null;
+
                 if (this.style === null) {
+                    setupSettingOption();
                     let settingObserver = new MutationObserver((mutations) => {
                         for (let mutation of mutations) {
                             for (let node of mutation.addedNodes) {
-                                if (node.nodeName.toLowerCase() === 'iron-dropdown' && node.classList.contains('yt-live-chat-app')) {
+                                const nodeName = node.nodeName.toLowerCase()
+                                if ((nodeName === 'iron-dropdown' || nodeName === 'tp-yt-iron-dropdown') && node.classList.contains('yt-live-chat-app')) {
                                     // i dont know why, but without the timeout the element doesn't appear :(
-                                    setTimeout(() => {
-                                        let settingOption = this.document.createElement('div');
-                                        settingOption.style.cursor = 'pointer';
-                                        settingOption.innerHTML = '<paper-item class="style-scope" role="option" tabindex="0" aria-disabled="false">BetterStreamChat</paper-item>';
-                                        node.querySelector('#items').appendChild(settingOption);
-                                        settingOption.addEventListener('click', () => {
-                                            BetterStreamChat.settingsDiv.style.display = 'block';
-                                            this.document.body.click(); // click on body to close the settings container lol
-                                        });
-                                        let popupRenderer = node.querySelector('ytd-menu-popup-renderer');
-                                        popupRenderer.style.removeProperty('max-height');
-                                    }, 50);
+                                    setTimeout(setupSettingOption, 50);
 
                                     settingObserver.disconnect();
                                     return;

--- a/src/init.js
+++ b/src/init.js
@@ -161,13 +161,13 @@ const Helper = {
         emotes: {},
         updateSettings() {
             let bttvEmoteList = BetterStreamChat.settingsDiv.querySelector(' #bttvEmoteList');
-            bttvEmoteList.innerText = '';
+            bttvEmoteList.textContent = '';
             for (let emote in this.emotes) {
                 if (this.emotes.hasOwnProperty(emote)) {
                     let li = document.createElement('li');
                     let img = document.createElement('img');
                     let span = document.createElement('span');
-                    span.innerText = emote;
+                    span.textContent = emote;
                     img.src = 'https://cdn.betterttv.net/emote/' + this.emotes[emote] + '/3x';
                     li.classList.add('emoteCard');
                     li.append(img);
@@ -177,7 +177,7 @@ const Helper = {
             }
 
             let list = BetterStreamChat.settingsDiv.querySelector('#bttvUserList');
-            list.innerText = '';
+            list.textContent = '';
             for (let userID in bttvUsers) {
                 if (bttvUsers.hasOwnProperty(userID)) {
                     this.addUserToList(userID, list);
@@ -360,7 +360,7 @@ const Helper = {
             let user = bttvUsers[userID];
             let li = document.createElement('li');
             li.id = 'bttvUser' + userID;
-            li.innerText = user.username + ' (last update: ' + (new Date(user.lastUpdate)).toLocaleString() + ')';
+            li.textContent = user.username + ' (last update: ' + (new Date(user.lastUpdate)).toLocaleString() + ')';
             list.append(li);
         }
     },
@@ -620,25 +620,25 @@ const YouTube = {
         if (settings.youtube.enabledColors) {
             let author = node.querySelector('#author-name');
             if (author) {
-                author.style.color = Helper.getUserChatColor(author.innerText);
+                author.style.color = Helper.getUserChatColor(author.textContent);
             }
         }
 
         let message = node.querySelector('#message');
         if (message) {
-            message.innerHTML = Helper.BTTV.replaceText(message.innerText);
+            message.innerHTML = Helper.BTTV.replaceText(message.innerHTML);
         }
 
         let timestamp = node.querySelector('#timestamp');
         if (settings.youtube.timestampFormat.toString() === '24' && timestamp) {
-            let timestampText = timestamp.innerText;
-            if (timestamp.innerText.toLowerCase().includes('pm')) {
-                let split = timestamp.innerText.split(':');
+            let timestampText = timestamp.textContent;
+            if (timestamp.textContent.toLowerCase().includes('pm')) {
+                let split = timestamp.textContent.split(':');
                 split[0] = (parseInt(split[0]) + 12).toString();
                 timestampText = split.join(':');
             }
 
-            timestamp.innerText = timestampText.replace(' PM', '').replace(' AM', '');
+            timestamp.textContent = timestampText.replace(' PM', '').replace(' AM', '');
         }
     },
     init() {
@@ -1169,7 +1169,7 @@ const Trovo = {
                 nickname.style.color = Helper.getUserChatColor(realname);
             }
             if (settings.trovo.fullName) {
-                nickname.innerText = realname;
+                nickname.textContent = realname;
             }
             if (settings.trovo.timestamp) {
                 let span = document.createElement('span');
@@ -1193,7 +1193,7 @@ const Trovo = {
 
                 // after inserted the emotes check the highlight words
                 let highlightWords = settings.general.highlightWords.trim().split(' ').filter((word) => word);
-                let contentText = content.innerText.toLowerCase();
+                let contentText = content.textContent.toLowerCase();
 
                 if (highlightWords.length >= 1) {
                     for (let idx = 0; idx < highlightWords.length; idx++) {
@@ -1212,7 +1212,7 @@ const Trovo = {
 
         if (node && settings.trovo.enabledColors) {
             for (let el of node.querySelectorAll('.at.text')) {
-                let name = el.innerText.substring(1);
+                let name = el.textContent.substring(1);
                 el.style.color = Helper.getUserChatColor(name);
             }
         }
@@ -1257,7 +1257,7 @@ const Trovo = {
                 console.log(liveInfo, liveInfo.__vue__);
                 if (liveInfo && liveInfo.__vue__) {
                     console.log('lol');
-                    liveInfo.querySelector('.viewer span').innerText = liveInfo.__vue__.liveInfo.channelInfo.viewers;
+                    liveInfo.querySelector('.viewer span').textContent = liveInfo.__vue__.liveInfo.channelInfo.viewers;
                 }
             }
             catch (e) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
 	"name": "BetterStreamChat",
-	"version": "1.3.4",
+	"version": "1.3.5",
 	"description": "Some settings for YouTube or Trovo chat.",
 	"manifest_version": 3,
 	"content_scripts": [

--- a/src/options.js
+++ b/src/options.js
@@ -156,7 +156,7 @@ const Settings = {
 			let user = bttvUsers[userID];
 			let li = document.createElement('li');
 			li.id = 'bttvUser' + userID;
-			li.innerText = user.username + ' (last update: ' + (new Date(user.lastUpdate)).toLocaleString() + ')';
+			li.textContent = user.username + ' (last update: ' + (new Date(user.lastUpdate)).toLocaleString() + ')';
 			list.append(li);
 		}
 	}
@@ -177,13 +177,13 @@ chrome.storage.local.get((items) => {
 
 Helper.BTTV.loaded = function () {
 	let bttvEmoteList = document.querySelector('#bttvEmoteList');
-	bttvEmoteList.innerText = '';
+	bttvEmoteList.textContent = '';
 	for (let emote in this.emotes) {
 		if (this.emotes.hasOwnProperty(emote)) {
 			let li = document.createElement('li');
 			let img = document.createElement('img');
 			let span = document.createElement('span');
-			span.innerText = emote;
+			span.textContent = emote;
 			img.src = 'https://cdn.betterttv.net/emote/' + this.emotes[emote] + '/3x';
 			li.classList.add('emoteCard');
 			li.append(img);


### PR DESCRIPTION
No functional changes. Just Bug Fixing.

1. For YouTube, previous coding is `message.innerHTML = Helper.BTTV.replaceText(message.innerText);` which led the emoji in messages being omitted.
      
      
      With BetterStreamChat
      <img width="360" src="https://na.cx/i/NWfcEhN.png">
      
      Without BetterStreamChat
      <img width="360" src="https://na.cx/i/CCOJLXp.png">
      
      ( Example Video: https://www.youtube.com/watch?v=MSSKKntjOEU )


2. `innerText` was wrongly used such that it leads to incompatibility to [YouTube Super Fast Chat](https://greasyfork.org/en/scripts/469878-youtube-super-fast-chat)
    * Detail Discussion see https://greasyfork.org/en/scripts/469878-youtube-super-fast-chat/discussions/197267
    
    As my script would hide the message initially for some reasons, your script reads its innerText would just read as empty text.
    The correct way is `textContent` which is fully supported in all modern browsers.
    Every time you read `innerText`, it will check the DOM tree whether it is visible or not. This makes the script slower.
    `textContent` is independent of DOM node tree.


3. I found that the script version is 1.3.4 in the manifest. updated to 1.3.5.
      
      You might further update it to 1.3.6 due to the bug fixing.

4. The element naming "iron-dropdown" and "paper-item" are quite old. The current naming is "tp-yt-iron-dropdown" and "tp-yt-paper-item". That's why in chrome extension website everyone is asking where is the option page. Now the setting page comes back.

## Remarks

Since I am not sure whether this project will update or not, as the last update (to 1.3.5) is already a year ago.
I uploaded the chrome extension version in https://github.com/cyfung1031/BetterStreamChat/tree/unpacked